### PR TITLE
Install `cryptography` < 3.4.0 to avoid PEP 517 requirement that curr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,7 @@ RUN \
     ### REQUIRED ###
     ### see https://github.com/janeczku/calibre-web/blob/master/requirements.txt
     ### https://github.com/janeczku/calibre-web/commit/1cb640e51e52bb6a02e2cecaf6cb3e9bd2b1349e
+        'cryptography<3.4.0' \
         'Babel>=1.3,<2.9' \
         'Flask-Babel>=0.11.1,<1.1.0' \
         'Flask-Login>=0.3.2,<0.5.1' \


### PR DESCRIPTION
I've implemented the simplest workaround to get the cryptography package to install. Version 3.4.0+ of the cryptography package requires PEP 517 and cannot be disabled with --no-use-pep517. I tried installing Rust using the 'apk' package manager ahead of the Python package installs (around Dockerfile#L180) but that also did not help.